### PR TITLE
fix Agg. Clustering ValueError with sample<2

### DIFF
--- a/eend/pytorch_backend/infer.py
+++ b/eend/pytorch_backend/infer.py
@@ -280,13 +280,14 @@ def infer(args):
 
         n_samples = n_chunks * args.num_speakers - len(sil_lst)
         min_n_samples = 2
-        if cls_num is not None:
+        if cls_num is not None and cls_num > min_n_samples:
             min_n_samples = cls_num
 
         if n_samples >= min_n_samples:
             # clustering (if cls_num is None, update cls_num)
-            clslab, cls_num =\
-                 clustering(args, svec, cls_num, ahc_dis_th, cl_lst, sil_lst)
+            clslab, cls_num = clustering(
+                args, svec, cls_num, ahc_dis_th, cl_lst, sil_lst
+            )
             # merge
             acti, clslab = merge_acti_clslab(args, acti, clslab, cls_num)
             # stitching


### PR DESCRIPTION
Currently, the following Error might arise when a trained EEND-vector model is used to do inference on an audio record with only a single speaker.
```
ValueError: Found array with 1 sample(s) (shape=(1, 1)) while a minimum of 2 is required by AgglomerativeClustering.
```

This PR fixes this issue by adding an extra verification to make sure `min_n_samples` is always greater than two which avoids doing clustering on one single sample.